### PR TITLE
Improve regex to eliminate ck/ik parameters in WWW-Authenticate

### DIFF
--- a/kamailio_icscf/icscf.cfg
+++ b/kamailio_icscf/icscf.cfg
@@ -13,6 +13,7 @@ alias=ims.mnc001.mcc001.3gppnetwork.org
 #!define HOSTNAME "icscf.ims.mnc001.mcc001.3gppnetwork.org"
 
 #!subst "/NETWORKNAME/ims.mnc001.mcc001.3gppnetwork.org/"
+#!subst "/HSS_REALM/epc.mnc001.mcc001.3gppnetwork.org/"
 
 #!define ENUM_SUFFIX "ims.mnc001.mcc001.3gppnetwork.org."
 

--- a/kamailio_icscf/icscf.cfg
+++ b/kamailio_icscf/icscf.cfg
@@ -13,7 +13,7 @@ alias=ims.mnc001.mcc001.3gppnetwork.org
 #!define HOSTNAME "icscf.ims.mnc001.mcc001.3gppnetwork.org"
 
 #!subst "/NETWORKNAME/ims.mnc001.mcc001.3gppnetwork.org/"
-#!subst "/HSS_REALM/epc.mnc001.mcc001.3gppnetwork.org/"
+#!subst "/HSS_REALM/ims.mnc001.mcc001.3gppnetwork.org/"
 
 #!define ENUM_SUFFIX "ims.mnc001.mcc001.3gppnetwork.org."
 

--- a/kamailio_icscf/kamailio_icscf.cfg
+++ b/kamailio_icscf/kamailio_icscf.cfg
@@ -163,7 +163,7 @@ modparam("cdp","config_file","/etc/kamailio_icscf/icscf.xml")
 #!ifdef CXDX_FORCED_PEER
 modparam("ims_icscf", "cxdx_forced_peer", CXDX_FORCED_PEER)
 #!endif
-modparam("ims_icscf","cxdx_dest_realm", NETWORKNAME)
+modparam("ims_icscf","cxdx_dest_realm", "HSS_REALM")
 
 # DB-URL, where information about S-CSCF-Server can be found:
 #!ifdef DB_URL2

--- a/kamailio_pcscf/route/register.cfg
+++ b/kamailio_pcscf/route/register.cfg
@@ -276,8 +276,7 @@ onreply_route[REGISTER_reply]
 				$var(old_hdr) = $hdr(WWW-Authenticate);
 				xnotice("Old header - WWW-Authenticate=$var(old_hdr)\n");
 				remove_hf("WWW-Authenticate");
-				$var(new_hdr) = $(hdr(WWW-Authenticate){re.subst,/[, ]*ck=\".*\"[,]/,/gi});
-				$var(new_hdr) = $(var(new_hdr){re.subst,/[, ]*ik=\".*\"[,]/,/gi});
+				$var(new_hdr) = $(hdr(WWW-Authenticate){re.subst,/(, *)?(ck|ik)=\"\w+\"//gi});
 				if ($(var(new_hdr){s.len}) > 0) {
 					append_hf("WWW-Authenticate: $var(new_hdr)\r\n");
 				}

--- a/kamailio_scscf/kamailio_scscf.cfg
+++ b/kamailio_scscf/kamailio_scscf.cfg
@@ -282,7 +282,7 @@ modparam("ims_auth", "registration_default_algorithm", REG_AUTH_DEFAULT_ALG)
 #!ifdef CXDX_FORCED_PEER
 modparam("ims_auth", "cxdx_forced_peer", CXDX_FORCED_PEER)
 #!endif
-modparam("ims_auth", "cxdx_dest_realm", NETWORKNAME)
+modparam("ims_auth", "cxdx_dest_realm", "HSS_REALM")
 modparam("ims_auth", "av_check_only_impu", 1)
 
 modparam("ims_auth", "max_nonce_reuse", 20)
@@ -307,7 +307,7 @@ modparam("ims_registrar_scscf", "support_wildcardPSI",1)
 modparam("ims_registrar_scscf", "user_data_xsd","/etc/kamailio_scscf/CxDataType_Rel7.xsd")
 modparam("ims_registrar_scscf", "scscf_name", URI)
 modparam("ims_registrar_scscf", "scscf_name", URI)
-modparam("ims_registrar_scscf", "cxdx_dest_realm", NETWORKNAME)
+modparam("ims_registrar_scscf", "cxdx_dest_realm", "HSS_REALM")
 modparam("ims_registrar_scscf", "append_branches", 1)
 modparam("ims_registrar_scscf", "user_data_always", 0)
 modparam("ims_registrar_scscf", "ue_unsubscribe_on_dereg", 1)

--- a/kamailio_scscf/scscf.cfg
+++ b/kamailio_scscf/scscf.cfg
@@ -14,6 +14,7 @@ listen=tcp:10.4.128.21:6060
 #!define URI "sip:scscf.ims.mnc001.mcc001.3gppnetwork.org:6060"
 
 #!subst "/NETWORKNAME/ims.mnc001.mcc001.3gppnetwork.org/"
+#!subst "/HSS_REALM/epc.mnc001.mcc001.3gppnetwork.org/"
 
 alias=scscf.ims.mnc001.mcc001.3gppnetwork.org
 

--- a/kamailio_scscf/scscf.cfg
+++ b/kamailio_scscf/scscf.cfg
@@ -14,7 +14,7 @@ listen=tcp:10.4.128.21:6060
 #!define URI "sip:scscf.ims.mnc001.mcc001.3gppnetwork.org:6060"
 
 #!subst "/NETWORKNAME/ims.mnc001.mcc001.3gppnetwork.org/"
-#!subst "/HSS_REALM/epc.mnc001.mcc001.3gppnetwork.org/"
+#!subst "/HSS_REALM/ims.mnc001.mcc001.3gppnetwork.org/"
 
 alias=scscf.ims.mnc001.mcc001.3gppnetwork.org
 


### PR DESCRIPTION
The previous regex were not specific enough : I had the case where the nonce ended with ck, causing the regex to truncate the nonce and corrupt the format. This new regex will detect parameter boundary without ambiguity